### PR TITLE
docs: define goal and roadmap

### DIFF
--- a/.artefacts/GOAL.md
+++ b/.artefacts/GOAL.md
@@ -1,0 +1,19 @@
+# Kanban Designer — Goal
+
+## Problem
+Agile coaches and team leads need a fast, no-setup way to design and visualize Kanban board layouts — column structures, WIP limits, swim lanes, and card-level detail — so they can explore board archetypes, teach Kanban concepts, and hand off a structured board to other tools in the suite, without committing to a heavyweight project-tracking backend.
+
+## Audience
+Agile coaches, Scrum Masters, and team leads who are sketching or teaching Kanban board designs during a workshop or planning session, and who want to share the result (via link, image, or JSON) or feed it into Sprint Metrics, Planning Poker, or Team Identity elsewhere in the Agile Tools suite.
+
+## Success criteria
+1. A user can build a board — columns, WIP limits, swim lanes — from scratch or from a template gallery of Kanban archetypes with educational context.
+2. A user can add, edit, colour, tag, assign, date, and checklist cards to model real work on the board.
+3. Board state round-trips via JSON export/import, exports as a PNG snapshot, and can be shared as a URL — all client-side, no server or login.
+4. The board integrates with the rest of the suite: writes localStorage state for the Dashboard and Planning Poker, and deep-links into Sprint Metrics.
+5. The UI works fully in EN/ES/BE/RU, supports light/dark theme, and is keyboard-navigable with ARIA roles.
+
+## Non-goals
+- Not a full project-management or issue-tracking system — no persistence backend, no multi-user real-time sync, no accounts.
+- Not a time-tracking or deep-analytics tool — the built-in stats panel is a summary only; detailed flow analytics belong to Sprint Metrics.
+- No server-side storage — all state lives in the browser (localStorage / URL fragment) or in exported files the user manages themselves.

--- a/.artefacts/ROADMAP.md
+++ b/.artefacts/ROADMAP.md
@@ -1,0 +1,39 @@
+# Kanban Designer — Roadmap
+
+Derived from GOAL.md. Rebuilt when GOAL changes or an epic ships.
+
+## Current epic
+None — idle. See `## Next epics` below.
+
+## Next epics
+1. **E1: Card description field** — serves #2. Multi-line notes per card: `<textarea>` in card edit mode, 1-line truncated preview on the card face, round-trips through JSON export and `kanban-designer:currentBoard`. [Issue #43](https://github.com/agile-toolkit/kanban-designer/issues/43) — `needs-review`, open since 2026-06-27, past the 7-day auto-approve threshold.
+2. **E2: Keyboard shortcuts help overlay** — serves #5. `?` key / toolbar button opens a modal listing all keyboard shortcuts (Navigation / Card actions / Board actions). [Issue #44](https://github.com/agile-toolkit/kanban-designer/issues/44) — `needs-review`, open since 2026-06-27, past the 7-day auto-approve threshold.
+3. **E3: Export board as CSV** — serves #3. Spreadsheet-ready card list (Column, Swim Lane, Title, Description, Colour, Due Date, Overdue), Blob-download `<board-name>-kanban.csv`. [Issue #45](https://github.com/agile-toolkit/kanban-designer/issues/45) — `needs-review`, open since 2026-06-27, past the 7-day auto-approve threshold.
+
+## Polish backlog
+- None currently filed — all open non-epic issues are either already implemented (awaiting human close, see Shipped below) or covered by E1–E3 above.
+
+## Shipped
+- ~~Board editor — columns, cards, WIP limits, import/export JSON~~
+- ~~Template gallery — 10 board archetypes with educational context~~
+- ~~EN/ES/BE/RU localization with in-app language switcher~~
+- ~~Card drag-and-drop within and between columns (`@dnd-kit`)~~
+- ~~Board image export (PNG snapshot)~~
+- ~~Card colour labels~~
+- ~~Shareable board URL (state encoded in URL fragment)~~
+- ~~Swim lane rows~~
+- ~~WIP limit progress bar~~
+- ~~Keyboard accessibility (ARIA roles, arrow/Enter/Delete navigation, skip link)~~
+- ~~Card search and filter (text, colour, swim lane)~~
+- ~~Unified AppHeader + language picker~~
+- ~~Light/dark theme~~
+- ~~Undo/redo (Ctrl+Z / Ctrl+Y, 50-entry history)~~
+- ~~Card due dates with overdue highlighting~~
+- ~~Column collapse/expand~~
+- ~~Card tags with tag filter~~
+- ~~Team Identity member assignment on cards~~
+- ~~Board statistics panel~~
+- ~~Card aging (time-in-column badge)~~
+- ~~Save board as custom template~~
+- ~~Card checklists with progress badge~~
+- ~~Integrations: Dashboard `lastSession` key, Sprint Metrics deep-link, Planning Poker `currentBoard` key~~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to Kanban Designer are documented here.
+
+## Unreleased
+
+- Docs-only pass: added `.artefacts/GOAL.md` and `.artefacts/ROADMAP.md`, filled in `README.md` with dev commands, `localStorage` keys, and tech notes, and added this changelog. No behavior change — these documents extract and formalize intent/state that previously only lived in `.artefacts/BRIEF.md`.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,45 @@
 # Kanban Designer
 
-An interactive Kanban board designer and configurator — define columns, set WIP limits, add swim lanes, and explore 10 board archetypes with educational context.
+An interactive Kanban board designer and configurator — define columns, set WIP limits, add swim lanes, and explore 10 board archetypes with educational context. Boards are editable client-side only: no backend, no accounts — state lives in `localStorage` and the URL.
 
 Part of the [Agile Tools](https://github.com/bthos) suite built on Management 3.0 and ICAgile source materials.
 
-## Stack
-React 18 · TypeScript · Vite · Tailwind CSS · @dnd-kit · react-i18next (EN/RU)
+See `.artefacts/GOAL.md` for why this app exists and `.artefacts/ROADMAP.md` for what's shipped and what's next.
 
-## Development
+## Stack
+React 18 · TypeScript · Vite · Tailwind CSS · @dnd-kit · react-i18next (EN/ES/BE/RU)
+
+## Dev commands
 ```bash
-npm install
-npm run dev
+npm install     # install dependencies
+npm run dev     # start Vite dev server
+npm run build   # tsc typecheck + production build
+npm run preview # preview the production build locally
 ```
 
 ## Deploy
 GitHub Pages via GitHub Actions on push to `main`.
 
+## localStorage keys
+
+| Key | Shape | Purpose |
+|-----|-------|---------|
+| `kanban-designer-boards` | `KanbanBoard[]` | All boards the user has created, persisted locally. |
+| `kanban-designer-current-id` | `string` | Id of the board currently open in the designer. |
+| `kanban-designer-board` | `KanbanBoard` (legacy) | Pre-multi-board single-board save; migrated into `kanban-designer-boards` on load, then removed. |
+| `kanban-designer:lastSession` | `{ boardName, columnCount, cardCount, boardCount, updatedAt }` | Summary written on every save, read by the suite Dashboard's "last session" card. |
+| `kanban-designer:currentBoard` | `{ boardName, columns: [{ name, cards: [{ title, description }] }], updatedAt }` | Written on every save; read by Planning Poker's "Send to Planning Poker" deep-link import. |
+| `kanban-designer:customTemplates` | `{ templates: [{ id, name, createdAt, board }] }` | User-saved board structures (columns/WIP/lanes only, no card content) shown in the Templates gallery. |
+| `theme` | `"light" \| "dark"` | Shared, suite-wide theme preference (unprefixed key by convention — read/written the same way by sibling apps under the same origin). |
+
+## Tech notes
+
+- **State management** — plain React state (`useState`/`useMemo`/`useRef`) in `App.tsx` and `BoardDesigner.tsx`; no external store. `App.tsx` owns the board list and undo/redo history (`boardHistory`/`boardFuture`, capped at 50 entries, Ctrl+Z/Ctrl+Y).
+- **i18n** — `react-i18next` with `i18next-browser-languagedetector`; four locale JSON files under `src/i18n/` (`en`, `es`, `be`, `ru`) with full key parity. A literal-key scan (`` t(\`templates.context.${key}\`) ``) is used for template context strings — grep-based dead-key checks will false-positive on it.
+- **Theme** — `tailwind.config.js` `darkMode: ['selector', '[data-theme="dark"]']`; an anti-flash inline `<script>` in `index.html` applies the stored theme before first paint; `ThemeToggle.tsx` flips `data-theme` on `<html>` and persists to the shared `theme` key.
+- **Shareable URL** — board state is base64-encoded into `window.location.hash` (`#board=<base64>`) via `history.replaceState` on every change; a board opened from a shared link is decoded on load and added to the local boards list.
+- **Cross-app integrations (same-origin `localStorage`)** — reads `team-identity-charter` (written by Team Identity) to populate the card assignee dropdown; writes `kanban-designer:lastSession` and `kanban-designer:currentBoard` for the Dashboard and Planning Poker respectively; "Send to Sprint Metrics" deep-links with board data base64-encoded in the query string rather than localStorage.
+- **Drag-and-drop** — `@dnd-kit` multi-container sortable (`closestCorners` collision detection); one vertical `SortableContext` per column, plus a `DragOverlay` ghost that mirrors card colour/lane.
+
 ## Source materials
-See `.artefacts/BRIEF.md` for full context and source file references.
+See `.artefacts/BRIEF.md` for the full run-by-run implementation history and source file references.


### PR DESCRIPTION
## Summary
- Adds `.artefacts/GOAL.md` (problem, audience, success criteria, non-goals) and `.artefacts/ROADMAP.md` (current epic, next epics derived from open GitHub issues, polish backlog, shipped log), extracted from the human-authored `.artefacts/BRIEF.md` without modifying it.
- Fills in `README.md` with dev commands, a `localStorage` keys table, and tech notes (state management, i18n, theme mechanism, cross-app integrations).
- Adds `CHANGELOG.md` with an `## Unreleased` entry noting this is a docs-only pass.

Docs-only — no source code, dependencies, or behavior changed.

## Test plan
- [x] Confirmed no source files touched (`git diff --stat` shows only `.artefacts/GOAL.md`, `.artefacts/ROADMAP.md`, `README.md`, `CHANGELOG.md`)
- [x] Cross-checked README's localStorage table against `grep -rn localStorage.setItem src/`
- [x] Cross-checked ROADMAP's "Next epics" against open GitHub issues (#43, #44, #45 — all `needs-review`, past the 7-day staleness threshold, not yet implemented per BRIEF.md)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DqHwojggZNH6G3ZhoqjhiW)_